### PR TITLE
Editor sidebar text CSS

### DIFF
--- a/src/themes/common.css
+++ b/src/themes/common.css
@@ -82,3 +82,7 @@
 .cm-editor .cm-panels.cm-panels-bottom {
   font-size: 16px;
 }
+/* sidebar text items css */
+span[class^='Online-Store-UI-NavItem'] span[class^='Polaris-Text'] {
+  font-size: 14px !important;
+}


### PR DESCRIPTION
After adding CSS settings, when we sets like 20px for editor fontsize, it works well. but it also update the sidebar text size to same size, and file name is not readable into this case. so I have added 14 px to add add fixed text size for editor sidebar text.